### PR TITLE
Update version control handling

### DIFF
--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -1,77 +1,36 @@
 set(LLVM_LINK_COMPONENTS mc)
 
-# Figure out if we can track VC revisions.
-function(find_first_existing_file out_var)
-  foreach(file ${ARGN})
-    if(EXISTS "${file}")
-      set(${out_var} "${file}" PARENT_SCOPE)
-      return()
-    endif()
-  endforeach()
-endfunction()
-
-macro(find_first_existing_vc_file out_var path)
-  set(git_path "${path}/.git")
-
-  # Normally '.git' is a directory that contains a 'logs/HEAD' file that
-  # is updated as modifications are made to the repository. In case the
-  # repository is a Git submodule, '.git' is a file that contains text that
-  # indicates where the repository's Git directory exists.
-  if (EXISTS "${git_path}" AND NOT IS_DIRECTORY "${git_path}")
-    FILE(READ "${git_path}" file_contents)
-    if("${file_contents}" MATCHES "^gitdir: ([^\n]+)")
-      # '.git' is indeed a link to the submodule's Git directory.
-      # Use the path to that Git directory.
-      set(git_path "${path}/${CMAKE_MATCH_1}")
-    endif()
-  endif()
-
-  find_first_existing_file(${out_var}
-    "${git_path}/logs/HEAD"  # Git or Git submodule
-    "${path}/.svn/wc.db"     # SVN 1.7
-    "${path}/.svn/entries"   # SVN 1.6
-    )
-endmacro()
-
-find_first_existing_vc_file(llvm_vc "${LLVM_MAIN_SRC_DIR}")
-find_first_existing_vc_file(fort_vc "${FORT_SOURCE_DIR}")
+find_first_existing_vc_file("${LLVM_MAIN_SRC_DIR}" llvm_vc)
+find_first_existing_vc_file("${FORT_SOURCE_DIR}" fort_vc) 
 
 # The VC revision include that we want to generate.
-set(version_inc "${CMAKE_CURRENT_BINARY_DIR}/SVNVersion.inc")
+set(version_inc "${CMAKE_CURRENT_BINARY_DIR}/VCSVersion.inc")
 
-set(get_svn_script "${LLVM_CMAKE_PATH}/GetSVN.cmake")
+set(generate_vcs_version_script "${LLVM_CMAKE_PATH}/GenerateVersionFromVCS.cmake")
 
-if(DEFINED llvm_vc AND DEFINED fort_vc)
-  # Create custom target to generate the VC revision include.
-  add_custom_command(OUTPUT "${version_inc}"
-    DEPENDS "${llvm_vc}" "${fort_vc}" "${get_svn_script}"
-    COMMAND
-    ${CMAKE_COMMAND} "-DFIRST_SOURCE_DIR=${LLVM_MAIN_SRC_DIR}"
-                     "-DFIRST_NAME=LLVM"
-                     "-DSECOND_SOURCE_DIR=${FORT_SOURCE_DIR}"
-                     "-DSECOND_NAME=SVN"
-                     "-DHEADER_FILE=${version_inc}"
-                     -P "${get_svn_script}")
-
-  # Mark the generated header as being generated.
-  set_source_files_properties("${version_inc}"
-    PROPERTIES GENERATED TRUE
-               HEADER_FILE_ONLY TRUE)
-
-  # Tell Version.cpp that it needs to build with -DHAVE_SVN_VERSION_INC.
-  set_source_files_properties(Version.cpp
-    PROPERTIES COMPILE_DEFINITIONS "HAVE_SVN_VERSION_INC")
-else()
-  # Not producing a VC revision include.
-  set(version_inc)
-
-  # Being able to force-set the SVN revision in cases where it isn't available
-  # is useful for performance tracking, and matches compatibility from autoconf.
-  if(SVN_REVISION)
-    set_source_files_properties(Version.cpp
-      PROPERTIES COMPILE_DEFINITIONS "SVN_REVISION=\"${SVN_REVISION}\"")
-  endif()
+if (llvm_vc)
+  set(llvm_source_dir ${LLVM_MAIN_SRC_DIR})
 endif()
+if (fort_vc)
+  set(fort_source_dir ${FORT_SOURCE_DIR})
+endif()
+
+# Create custom target to generate the VC revision include.
+add_custom_command(OUTPUT "${version_inc}"
+  DEPENDS "${llvm_vc}" "${fort_vc}" "${generate_vcs_version_script}"
+  COMMAND ${CMAKE_COMMAND} "-DNAMES=\"LLVM;FORT\""
+                           "-DLLVM_SOURCE_DIR=${llvm_source_dir}"
+                           "-DFORT_SOURCE_DIR=${fort_source_dir}"
+                           "-DHEADER_FILE=${version_inc}"
+                           -P "${generate_vcs_version_script}")
+
+# Mark the generated header as being generated.
+set_source_files_properties("${version_inc}"
+  PROPERTIES GENERATED TRUE
+             HEADER_FILE_ONLY TRUE)
+
+set_property(SOURCE Version.cpp APPEND PROPERTY
+             COMPILE_DEFINITIONS "HAVE_VCS_VERSION_INC")
 
 add_fort_library(fortBasic
   CharInfo.cpp

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -18,8 +18,8 @@
 #include <cstdlib>
 #include <cstring>
 
-#ifdef HAVE_SVN_VERSION_INC
-#include "SVNVersion.inc"
+#ifdef HAVE_VCS_VERSION_INC
+#include "VCSVersion.inc"
 #endif
 
 namespace fort {
@@ -28,18 +28,18 @@ std::string getFortRepositoryPath() {
 #if defined(FORT_REPOSITORY_STRING)
   return FORT_REPOSITORY_STRING;
 #else
-#ifdef SVN_REPOSITORY
-  StringRef URL(SVN_REPOSITORY);
+#ifdef FORT_REPOSITORY
+  StringRef URL(FORT_REPOSITORY);
 #else
   StringRef URL("");
 #endif
 
-  // If the SVN_REPOSITORY is empty, try to use the SVN keyword. This helps us
-  // pick up a tag in an SVN export, for example.
-  StringRef SVNRepository("$URL$");
+  // If the FORT_REPOSITORY is empty, try to use the VCS keyword. This helps us
+  // pick up a tag in an VCS export, for example.
+  StringRef VCSRepository("$URL$");
   if (URL.empty()) {
-    URL = SVNRepository.slice(SVNRepository.find(':'),
-                              SVNRepository.find("/lib/Basic"));
+    URL = VCSRepository.slice(VCSRepository.find(':'),
+                              VCSRepository.find("/lib/Basic"));
   }
 
   // Strip off version from a build from an integration branch.
@@ -72,8 +72,8 @@ std::string getLLVMRepositoryPath() {
 }
 
 std::string getFortRevision() {
-#ifdef SVN_REVISION
-  return SVN_REVISION;
+#ifdef FORT_REVISION
+  return FORT_REVISION;
 #else
   return "";
 #endif


### PR DESCRIPTION
Follow the change made to LLVM to consolidate handling of version information
in dev builds. Rely on the scripts in LLVM CMake directory. Rename "SVNVersion"
to more appropriate "VCSVersion".

Fixes #27 
