### PR TITLE
Parse ALLOCATE and DEALLOCATE statements

### DIFF
--- a/include/fort/Basic/DiagnosticParseKinds.td
+++ b/include/fort/Basic/DiagnosticParseKinds.td
@@ -95,6 +95,9 @@ def err_expected_do_var : Error<
 def err_expected_int_var : Error<
   "expected an integer variable after '%0'">;
 
+def err_expected_array_spec: Error<
+  "expected array specification">;
+
 def err_expected_after_recursive : Error<
   "expected 'function' or 'subroutine' after 'recursive'">;
 def err_expected_fn_body : Error<

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1952,26 +1952,12 @@ Parser::StmtResult Parser::ParseVALUEStmt() { return StmtResult(); }
 ///         VOLATILE [::] object-name-list
 Parser::StmtResult Parser::ParseVOLATILEStmt() { return StmtResult(); }
 
-/// ParseALLOCATEStmt - Parse the ALLOCATE statement.
-///
-///   [R623]:
-///     allocate-stmt :=
-///         ALLOCATE ( [ type-spec :: ] alocation-list [ , alloc-opt-list ] )
-Parser::StmtResult Parser::ParseALLOCATEStmt() { return StmtResult(); }
-
 /// ParseNULLIFYStmt - Parse the NULLIFY statement.
 ///
 ///   [R633]:
 ///     nullify-stmt :=
 ///         NULLIFY ( pointer-object-list )
 Parser::StmtResult Parser::ParseNULLIFYStmt() { return StmtResult(); }
-
-/// ParseDEALLOCATEStmt - Parse the DEALLOCATE statement.
-///
-///   [R635]:
-///     deallocate-stmt :=
-///         DEALLOCATE ( allocate-object-list [ , dealloc-op-list ] )
-Parser::StmtResult Parser::ParseDEALLOCATEStmt() { return StmtResult(); }
 
 /// ParseFORALLStmt - Parse the FORALL construct statement.
 ///

--- a/test/Parser/dynamicAssociation.f95
+++ b/test/Parser/dynamicAssociation.f95
@@ -1,0 +1,13 @@
+! RUN: %fort -fsyntax-only -verify %s
+program a
+  ! TODO defferred shape
+  integer, allocatable :: a(10), b(10, 10), c(10,10,10)
+  allocate(8) ! expected-error {{expected identifier}}
+  allocate(a(10), ! expected-error {{expected identifier}}
+  allocate(b(10,10) ! expected-error {{expected ')'}}
+  allocate(a) ! expected-error {{expected '('}}
+  continue ! expected-error@-1 {{expected array specification}}
+  deallocate(.5) ! expected-error {{expected identifier}}
+  deallocate(c ! expected-error {{expected ')'}}
+  deallocate(a,) ! expected-error {{expected identifier}}
+end program


### PR DESCRIPTION
Support `allocate` and `deallocate` statements in the parser. Add an error mode
for missing array specification for the allocation statement. Add a test for
parsing errors. No semantic analysis or AST support yet.

For issue #24

