### PR TITLE
Emit heap allocations

### DIFF
--- a/lib/CodeGen/CGDecl.cpp
+++ b/lib/CodeGen/CGDecl.cpp
@@ -58,7 +58,7 @@ void CodeGenFunction::EmitVarDecl(const VarDecl *D) {
     HasSavedVariables = true;
   } else {
     if (Type->isArrayType())
-      Ptr = CreateArrayAlloca(Type, D->getName());
+      Ptr = CreateArrayTypeAlloca(Type, D->getName());
     else
       Ptr =
           Builder.CreateAlloca(ConvertTypeForMem(Type), nullptr, D->getName());

--- a/lib/CodeGen/CGStmt.cpp
+++ b/lib/CodeGen/CGStmt.cpp
@@ -47,6 +47,7 @@ public:
   void VisitComputedGotoStmt(const ComputedGotoStmt *S) {
     CGF.EmitComputedGotoStmt(S);
   }
+  void VisitAllocateStmt(const AllocateStmt *S) { CGF.EmitAllocateStmt(S); }
   void VisitDeallocateStmt(const DeallocateStmt *S) {
     CGF.EmitDeallocateStmt(S);
   }
@@ -194,6 +195,17 @@ void CodeGenFunction::EmitComputedGotoStmt(const ComputedGotoStmt *S) {
     Switch->addCase(cast<llvm::ConstantInt>(Val), Dest);
   }
   EmitBlock(DefaultCase);
+}
+
+void CodeGenFunction::EmitAllocateStmt(const AllocateStmt *S) {
+  for (auto Arg : S->getArguments()) {
+    auto Alloc = dyn_cast<AllocExpr>(Arg);
+    assert(Alloc && "Expecting allocate expression");
+    auto Ptr = CreateHeapArrayAlloca(Alloc);
+    auto Target = Alloc->getTarget();
+    auto Loc = EmitLValue(Target);
+    EmitStore(Ptr, Loc, Target->getType());
+  }
 }
 
 void CodeGenFunction::EmitDeallocateStmt(const DeallocateStmt *S) {

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -203,8 +203,8 @@ public:
 
   void EmitCommonBlock(const CommonBlockSet *S);
 
-  llvm::Value *CreateArrayAlloca(QualType T, const llvm::Twine &Name = "",
-                                 bool IsTemp = false);
+  llvm::Value *CreateArrayTypeAlloca(QualType T, const llvm::Twine &Name = "",
+                                     bool IsTemp = false);
 
   /// CreateTempAlloca - This creates a alloca and inserts it into the entry
   /// block. The caller is responsible for setting an appropriate alignment on
@@ -223,6 +223,9 @@ public:
   llvm::Value *CreateTempHeapArrayAlloca(QualType T,
                                          const ArrayValueRef &Value);
 
+  /// CreateHeapArrayAlloca - This allocates an array on the heap
+  llvm::Value *CreateHeapArrayAlloca(AllocExpr *Alloc);
+
   void EmitBlock(llvm::BasicBlock *BB);
   void EmitBranch(llvm::BasicBlock *Target);
   void EmitBranchOnLogicalExpr(const Expr *Condition, llvm::BasicBlock *ThenBB,
@@ -237,6 +240,7 @@ public:
   void EmitAssignedGotoStmt(const AssignedGotoStmt *S);
   void EmitAssignedGotoDispatcher();
   void EmitComputedGotoStmt(const ComputedGotoStmt *S);
+  void EmitAllocateStmt(const AllocateStmt *S);
   void EmitDeallocateStmt(const DeallocateStmt *S);
   void EmitIfStmt(const IfStmt *S);
   void EmitDoStmt(const DoStmt *S);
@@ -482,6 +486,8 @@ public:
   ArrayDimensionValueTy GetVectorDimensionInfo(QualType T);
 
   void GetArrayDimensionsInfo(QualType T,
+                              SmallVectorImpl<ArrayDimensionValueTy> &Dims);
+  void GetArrayDimensionsInfo(const ArrayType *ATy,
                               SmallVectorImpl<ArrayDimensionValueTy> &Dims);
 
   llvm::Value *EmitArrayArgumentPointerValueABI(const Expr *E);

--- a/lib/Parse/ParseExec.cpp
+++ b/lib/Parse/ParseExec.cpp
@@ -684,6 +684,7 @@ Parser::StmtResult Parser::ParseALLOCATEStmt() {
     return StmtError();
 
   // TODO [ type-spec :: ]
+  // TODO (Language standard specific)
 
   // allocation-list
   SmallVector<ExprResult, 4> Alloc;

--- a/test/CodeGen/memory.f95
+++ b/test/CodeGen/memory.f95
@@ -1,7 +1,13 @@
-! RUN: %fort %s -S -emit-llvm -o - | %file_check %s
+! RUN: %fort %s -O0 -S -emit-llvm -o - | %file_check %s
 program p
-  integer, allocatable :: a(10), b(5) ! CHECK: %a = alloca i32*
-  continue                            ! CHECK: %b = alloca i32*
+  integer(kind=4), allocatable :: a(10), b(5) ! CHECK: %a = alloca i32*
+  continue                                    ! CHECK: %b = alloca i32*
+  allocate(a(10), b(5)) ! CHECK: @libfort_malloc({{.*}}40)
+  continue              ! CHECK-NEXT: bitcast i8* {{.*}} to i32*
+  continue              ! CHECK-NEXT: store i32* {{.*}}, i32** %a
+  continue              ! CHECK: @libfort_malloc({{.*}}20)
+  continue              ! CHECK-NEXT: bitcast i8* {{.*}} to i32*
+  continue              ! CHECK-NEXT: store i32* {{.*}}, i32** %b
   deallocate(a,b) ! CHECK: load {{.*}} %a
   continue        ! CHECK: call void @libfort_free
   continue        ! CHECK: load {{.*}} %b


### PR DESCRIPTION
Produce a call to malloc with the right size, store ptr to allocated memory in
the variable.

Bitcast malloc's return value to the right pointer size, store to the target
symbol.

Add all of that to the test.

For #22
