### PR TITLE
Expect new label syntax

### DIFF
--- a/test/CodeGen/goto.f95
+++ b/test/CodeGen/goto.f95
@@ -1,7 +1,7 @@
 ! RUN: %fort -emit-llvm -o - %s | %file_check %s
 PROGRAM gototest
 
-1000 CONTINUE   ! CHECK: ; <label>:0
+1000 CONTINUE   ! CHECK: 0:
      GOTO 1000  ! CHECK: br label %0
 
      GOTO 2000


### PR DESCRIPTION
LLVM changed the way numeric labels are printed in IR output, removing
`<label>` preceeding numeric ID.

Upstream change that introduced this is

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@356789 91177308-0d34-0410-b5e6-96231b3b80d8

Fixes #38 
