### PR TITLE
Enable C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,11 +233,6 @@ configure_file(
 
 #include(LLVMParseArguments)
 
-# Enable C++ 11
-if(NOT MSVC)
-  add_definitions(-std=c++11)
-endif()
-
 function(fort_tablegen)
   # Syntax:
   # fort_tablegen output-file [tablegen-arg ...] SOURCE source-file

--- a/lib/Driver/DriverOptions.cpp
+++ b/lib/Driver/DriverOptions.cpp
@@ -41,7 +41,7 @@ public:
 }
 
 std::unique_ptr<OptTable> fort::driver::createDriverOptTable() {
-  auto Result = llvm::make_unique<DriverOptTable>();
+  auto Result = std::make_unique<DriverOptTable>();
   // Options.inc is included in DriverOptions.cpp, and calls OptTable's
   // addValues function.
   // Opt is a variable used in the code fragment in Options.inc.


### PR DESCRIPTION
Allow C++14 to cascade down from LLVM and use std:: for templates no longer in
LLVM code base.

