### PR TITLE
TokenKinds: add punctuators

### DIFF
--- a/include/fort/Basic/TokenKinds.def
+++ b/include/fort/Basic/TokenKinds.def
@@ -17,6 +17,9 @@
 #ifndef TOK
 #define TOK(X)
 #endif
+#ifndef PUNCTUATOR
+#define PUNCTUATOR(X,Y) TOK(X)
+#endif
 #ifndef KEYWORD
 #define KEYWORD(X,Y) TOK(kw_ ## X)
 #endif
@@ -71,46 +74,46 @@ TOK(logical_literal_constant) // .TRUE., .FALSE.
 // [R309]: Intrinsic Operator
 TOK(intrinsic_operator)  // .EQ., .NE., ...
 
-// [FIXME]: Punctuators.
-TOK(equal)               // =
-TOK(equalequal)          // ==
-TOK(equalgreater)        // =>
-TOK(plus)                // +
-TOK(minus)               // -
-TOK(star)                // *
-TOK(starstar)            // **
-TOK(slash)               // /
-TOK(slashslash)          // //
-TOK(slashequal)          // /=
-TOK(backslash)           // <backslash>
-TOK(l_parenslash)        // (/
-TOK(slashr_paren)        // /)
-TOK(l_paren)             // (
-TOK(r_paren)             // )
-TOK(l_square)            // [
-TOK(r_square)            // ]
-TOK(l_brace)             // {
-TOK(r_brace)             // }
-TOK(comma)               // ,
-TOK(period)              // .
-TOK(colon)               // :
-TOK(coloncolon)          // ::
-TOK(semicolon)           // ;
-TOK(exclaim)             // !
-TOK(percent)             // %
-TOK(ampersand)           // &
-TOK(tilde)               // ~
-TOK(less)                // <
-TOK(lessequal)           // <=
-TOK(greater)             // >
-TOK(greaterequal)        // >=
-TOK(question)            // ?
-TOK(backtick)            // `
-TOK(caret)               // ^
-TOK(pipe)                // |
-TOK(dollar)              // $
-TOK(hash)                // #
-TOK(at)                  // @
+// Punctuators.
+PUNCTUATOR(equal,               "=")
+PUNCTUATOR(equalequal,          "==")
+PUNCTUATOR(equalgreater,        "=>")
+PUNCTUATOR(plus,                "+")
+PUNCTUATOR(minus,               "-")
+PUNCTUATOR(star,                "*")
+PUNCTUATOR(starstar,            "**")
+PUNCTUATOR(slash,               "/")
+PUNCTUATOR(slashslash,          "//")
+PUNCTUATOR(slashequal,          "/=")
+PUNCTUATOR(backslash,           "\\")
+PUNCTUATOR(l_parenslash,        "(/")
+PUNCTUATOR(slashr_paren,        "/)")
+PUNCTUATOR(l_paren,             "(")
+PUNCTUATOR(r_paren,             ")")
+PUNCTUATOR(l_square,            "[")
+PUNCTUATOR(r_square,            "]")
+PUNCTUATOR(l_brace,             "{")
+PUNCTUATOR(r_brace,             "}")
+PUNCTUATOR(comma,               ",")
+PUNCTUATOR(period,              ".")
+PUNCTUATOR(colon,               ":")
+PUNCTUATOR(coloncolon,          "::")
+PUNCTUATOR(semicolon,           ";")
+PUNCTUATOR(exclaim,             "!")
+PUNCTUATOR(percent,             "%")
+PUNCTUATOR(ampersand,           "&")
+PUNCTUATOR(tilde,               "~")
+PUNCTUATOR(less,                "<")
+PUNCTUATOR(lessequal,           "<=")
+PUNCTUATOR(greater,             ">")
+PUNCTUATOR(greaterequal,        ">=")
+PUNCTUATOR(question,            "?")
+PUNCTUATOR(backtick,            "`")
+PUNCTUATOR(caret,               "^")
+PUNCTUATOR(pipe,                "|")
+PUNCTUATOR(dollar,              "$")
+PUNCTUATOR(hash,                "#")
+PUNCTUATOR(at,                  "@")
 
 // [FIXME]: Keywords. These turn into kw_* tokens. All keywords may be
 // redefined. So these are `keywords' only in a context where they need to be a

--- a/include/fort/Basic/TokenKinds.h
+++ b/include/fort/Basic/TokenKinds.h
@@ -14,12 +14,14 @@
 #ifndef LLVM_FORT_TOKENKINDS_H__
 #define LLVM_FORT_TOKENKINDS_H__
 
+#include "llvm/Support/Compiler.h"
+
 namespace fort {
 namespace tok {
 
 /// TokenKind - This provides a simple uniform namespace for tokens from all
 /// Fortran languages.
-enum TokenKind {
+enum TokenKind : unsigned short {
 #define TOK(X) X,
 #include "fort/Basic/TokenKinds.def"
   NUM_TOKENS
@@ -30,6 +32,19 @@ enum TokenKind {
 /// The name of a token will be an internal name (such as "l_paren") and should
 /// not be used as part of diagnostic messages.
 const char *getTokenName(enum TokenKind Kind);
+
+/// Determines the spelling of simple punctuation tokens like
+/// '!' or '%', and returns NULL for literal and annotation tokens.
+///
+/// This routine only retrieves the "simple" spelling of the token,
+/// and will not produce any alternative spellings (e.g., a
+/// digraph). For the actual spelling of a given Token, use
+/// Preprocessor::getSpelling().
+const char *getPunctuatorSpelling(TokenKind Kind) LLVM_READNONE;
+
+/// Determines the spelling of simple keyword and contextual keyword
+/// tokens like 'int' and 'dynamic_cast'. Returns NULL for other token kinds.
+const char *getKeywordSpelling(TokenKind Kind) LLVM_READNONE;
 
 /// \brief Determines the spelling of simple punctuation tokens like '**' or
 /// '(', and returns NULL for literal and annotation tokens.

--- a/lib/Basic/TokenKinds.cpp
+++ b/lib/Basic/TokenKinds.cpp
@@ -107,4 +107,22 @@ const char *tok::getTokenSimpleSpelling(enum TokenKind Kind) {
   return 0;
 }
 
+const char *tok::getPunctuatorSpelling(TokenKind Kind) {
+  switch (Kind) {
+#define PUNCTUATOR(X,Y) case X: return Y;
+#include "fort/Basic/TokenKinds.def"
+  default: break;
+  }
+  return nullptr;
+}
+
+const char *tok::getKeywordSpelling(TokenKind Kind) {
+  switch (Kind) {
+#define KEYWORD(X,Y) case kw_ ## X: return #X;
+#include "fort/Basic/TokenKinds.def"
+    default: break;
+  }
+  return nullptr;
+}
+
 } // namespace fort


### PR DESCRIPTION
Add punctuator macro and allow producing better diagnostics for punctuators.

Closes #41
